### PR TITLE
eggd_conductor_dias_TWE_config_v1.1.0.json

### DIFF
--- a/assay_configs/TWE/eggd_conductor_dias_TWE_config_v1.1.0.json
+++ b/assay_configs/TWE/eggd_conductor_dias_TWE_config_v1.1.0.json
@@ -1,11 +1,12 @@
 {
     "name": "Config for Twist whole exome assay",
     "assay": "TWE",
-    "assay_code": "EGG4",
+    "assay_code": "-EGG4|-9526-|-9688-",
     "version": "1.1.0",
-    "details": "Includes main Dias workflow, single, multi, QC and reports",
+    "details": "Includes main Dias workflows: single, multi and QC reports",
     "changelog": {
-        "v1.0.0": "Initial working version"
+        "v1.0.0": "Initial working version",
+        "v1.1.0": "Updated dias_single and dias_multi workflows, specifying input files"
     },
     "demultiplex": true,
     "demultiplex_config": {
@@ -15,47 +16,110 @@
         "org-emee_1": "CONTRIBUTE"
     },
     "executables": {
-        "workflow-G5gzKx8433GYp8x7FkjV1J2j": {
-            "name": "dias_single_v1.3.0",
+        "workflow-GV35kQj4P1ggx5gYFZGb3zFK": {
+            "name": "dias_single_v2.1.0",
             "details": "Dias single workflow - Runs Sentieon, multi_fastqc, verifyBAM_ID, vcf_QC, flagstat, Picard, mosdepth, somalier extract using the fastqs out of demultiplexing step",
             "url": "https://github.com/eastgenomics/eggd_dias_single_workflow",
             "analysis": "analysis_1",
             "per_sample": true,
             "process_fastqs": true,
             "inputs": {
-                "stage-Fy6fpV840vZZ0v6J8qBQYqZF.fastqs": "INPUT-R1-R2",
-                "stage-Fy6fpk040vZZPPbq96Jb2KfK.reads_fastqgzs": "INPUT-R1",
-                "stage-Fy6fpk040vZZPPbq96Jb2KfK.reads2_fastqgzs": "INPUT-R2",
-                "stage-Fy6fqy040vZV3Gj24vppvJgZ.bed_file": {
-                    "$dnanexus_link": "file-Fpz2X0Q433GVK5xxPvzqvVPB"
+                "stage-fastQC.fastqs": "INPUT-R1-R2",
+                "stage-sentieon_dnaseq.sample": "INPUT-SAMPLE-NAME",
+                "stage-sentieon_dnaseq.reads_fastqgzs": "INPUT-R1",
+                "stage-sentieon_dnaseq.reads2_fastqgzs": "INPUT-R2",
+                "stage-sentieon_dnaseq.output_metrics": true,
+                "stage-sentieon_dnaseq.ignore_decoy": true,
+                "stage-sentieon_dnaseq.genome_fastagz": {
+                    "$dnanexus_link": {
+                        "project": "project-F3zxk7Q4F30Xp8fG69K1Vppj",
+                        "id": "file-F403K904F30y2vpVFqxB9kz7"
+                    }
                 },
-                "stage-G21GzGj433Gky42j42Q5bJkf.input_bed": {
-                    "$dnanexus_link": "file-Fpz2X0Q433GVK5xxPvzqvVPB"
+                "stage-sentieon_dnaseq.genomebwaindex_targz": {
+                    "$dnanexus_link": {
+                        "project": "project-F3zxk7Q4F30Xp8fG69K1Vppj",
+                        "id": "file-F404y604F30fbxQG68KF3GZb"
+                    }
                 },
-                "stage-Fy6fvYQ40vZV1y8p9GYKPYyQ.bed": {
-                    "$dnanexus_link": "file-Fpz2X0Q433GVK5xxPvzqvVPB"
+                "stage-sentieon_dnaseq.gatk_resource_bundle": {
+                    "$dnanexus_link": {
+                        "project": "project-F3zqGV04fXX5j7566869fjFq",
+                        "id": "file-F3zx7gj4fXX8QG3Q42BzpyZJ"
+                    }
                 },
-                "stage-Fy6fx2Q40vZbFVxZ283xXGVY.bedfile": {
-                    "$dnanexus_link": "file-G2J5ZV0433GQJz7860vb4PB1"
+                "stage-verifybamid.vcf_file": {
+                    "$dnanexus_link": {
+                        "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+                        "id": "file-G08V2gj41zgGYp1K79YZXqx8"
+                    }
+                },
+                "stage-vcfQC.bed_file": {
+                    "$dnanexus_link": {
+                        "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+                        "id": "file-Fpz2X0Q433GVK5xxPvzqvVPB"
+                    }
+                },
+                "stage-picardQC.run_CollectMultipleMetrics": false,
+                "stage-picardQC.run_CollectHsMetrics": true,
+                "stage-picardQC.run_CollectTargetedPcrMetrics": false,
+                "stage-picardQC.fasta_index": {
+                    "$dnanexus_link": {
+                        "project": "project-F3zqGV04fXX5j7566869fjFq",
+                        "id": "file-F3zxG0Q4fXX9YFjP1v5jK9jf"
+                    }
+                },
+                "stage-picardQC.bedfile": {
+                    "$dnanexus_link": {
+                        "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+                        "id": "file-G2J5ZV0433GQJz7860vb4PB1"
+                    }
+                },
+                "stage-mosdepth.bed": {
+                    "$dnanexus_link": {
+                        "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+                        "id": "file-Fpz2X0Q433GVK5xxPvzqvVPB"
+                    }
+                },
+                "stage-somalier_extract.somalier_docker": {
+                    "$dnanexus_link": {
+                        "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+                        "id": "file-GPQX4G04x14XV5PFfqGkGJk1"
+                    }
+                },
+                "stage-somalier_extract.reference_genome": {
+                    "$dnanexus_link": {
+                        "project": "project-Fv2gqv04kxV0QZgY3gZ1VG0P",
+                        "id": "file-F403K904F30y2vpVFqxB9kz7"
+                    }
+                },
+                "stage-somalier_extract.reference_genome_index": {
+                    "$dnanexus_link": {
+                        "project": "project-Fv2gqv04kxV0QZgY3gZ1VG0P",
+                        "id": "file-F3zxG0Q4fXX9YFjP1v5jK9jf"
+                    }
+                },
+                "stage-somalier_extract.snp_site_vcf": {
+                    "$dnanexus_link": {
+                        "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+                        "id": "file-G18PB8Q4vQpfvPv83qKpj2QG"
+                    }
                 }
             },
             "output_dirs": {
-                "stage-Fy6fpV840vZZ0v6J8qBQYqZF": "/OUT-FOLDER/STAGE-NAME",
-                "stage-Fy6fpk040vZZPPbq96Jb2KfK": "/OUT-FOLDER/STAGE-NAME",
-                "stage-Fy6fq5840vZfYPKj25827FbZ": "/OUT-FOLDER/STAGE-NAME",
-                "stage-Fy6fqQj40vZqfGBg6YXxyV1x": "/OUT-FOLDER/STAGE-NAME",
-                "stage-Fy6fqf840vZx8V5KBzfYZvPg": "/OUT-FOLDER/STAGE-NAME",
-                "stage-Fy6fqy040vZV3Gj24vppvJgZ": "/OUT-FOLDER/STAGE-NAME",
-                "stage-G21GzGj433Gky42j42Q5bJkf": "/OUT-FOLDER/STAGE-NAME",
-                "stage-Fy6fvx040vZfybXg85Zgkjv0": "/OUT-FOLDER/STAGE-NAME",
-                "stage-Fy6fx2Q40vZbFVxZ283xXGVY": "/OUT-FOLDER/STAGE-NAME",
-                "stage-Fy6fvYQ40vZV1y8p9GYKPYyQ": "/OUT-FOLDER/STAGE-NAME",
-                "stage-G5gzP78433GVJ1z1PBKBqxzy": "/OUT-FOLDER/STAGE-NAME"
+                "stage-fastQC": "/OUT-FOLDER/STAGE-NAME",
+                "stage-sentieon_dnaseq": "/OUT-FOLDER/STAGE-NAME",
+                "stage-verifybamid": "/OUT-FOLDER/STAGE-NAME",
+                "stage-vcfQC": "/OUT-FOLDER/STAGE-NAME",
+                "stage-samtools_flagstat": "/OUT-FOLDER/STAGE-NAME",
+                "stage-picardQC": "/OUT-FOLDER/STAGE-NAME",
+                "stage-mosdepth": "/OUT-FOLDER/STAGE-NAME",
+                "stage-somalier_extract": "/OUT-FOLDER/STAGE-NAME"
             }
         },
-        "workflow-G5j1j28433GYkv4gPpPG8g11": {
-            "name": "dias_multi_v1.2.0",
-            "details": "Dias multi workflow - Takes all fastqs of all samples, starts Hap.py and somalier relate jobs",
+        "workflow-GV40KG04bz43357995BqBQJY": {
+            "name": "dias_multi_v2.0.0",
+            "details": "Dias multi workflow - starts Hap.py and somalier_relate jobs",
             "url": "https://github.com/eastgenomics/eggd_dias_multi_workflow",
             "analysis": "analysis_2",
             "per_sample": false,
@@ -64,45 +128,95 @@
                 "analysis_1"
             ],
             "inputs": {
-                "stage-Fybykxj433GV7vJKFGf3yVkK.SampleSheet": {
+                "stage-update_runfolders.SampleSheet": {
                     "$dnanexus_link": "INPUT-SAMPLESHEET"
                 },
-                "stage-Fq1BPKj433Gx3K4Y8J35j0fv.prefix": "NA12878",
-                "stage-Fq1BPKj433Gx3K4Y8J35j0fv.panel_bed": {
-                    "$dnanexus_link": "file-G2V8k90433GVQ7v07gfj0ggX"
-                },
-                "stage-Fq1BPKj433Gx3K4Y8J35j0fv.query_vcf": {
+                "stage-vcfeval_happy.query_vcf": {
                     "$dnanexus_link": {
                         "analysis": "analysis_1",
-                        "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+                        "stage": "stage-sentieon_dnaseq",
                         "field": "variants_vcf"
                     }
                 },
-                "stage-G5j1jJj433GpFY3v0JZQ2ZZ0.somalier_extract_file": {
+                "stage-vcfeval_happy.truth_vcf": {
+                    "$dnanexus_link": {
+                        "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+                        "id": "file-FjkzKVQ4yBGkQQg53bX957G7"
+                    }
+                },
+                "stage-vcfeval_happy.panel_bed": {
+                    "$dnanexus_link": {
+                        "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+                        "id": "file-G2V8k90433GVQ7v07gfj0ggX"
+                    }
+                },
+                "stage-vcfeval_happy.high_conf_bed": {
+                    "$dnanexus_link": {
+                        "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+                        "id": "file-FjkzKPQ4yBGgBgJ6KvyZ563P"
+                    }
+                },
+                "stage-vcfeval_happy.reference_fasta": {
+                    "$dnanexus_link": {
+                        "project": "project-F3zxk7Q4F30Xp8fG69K1Vppj",
+                        "id": "file-F403K904F30y2vpVFqxB9kz7"
+                    }
+                },
+                "stage-vcfeval_happy.reference_fasta_index": {
+                    "$dnanexus_link": {
+                        "project": "project-F3zxk7Q4F30Xp8fG69K1Vppj",
+                        "id": "file-F3zyVj84F30jxYxG68vJyg68"
+                    }
+                },
+                "stage-vcfeval_happy.reference_sdf_tar": {
+                    "$dnanexus_link": {
+                        "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+                        "id": "file-Fjp4k3j4yBGpK4x73bzbG2P0"
+                    }
+                },
+                "stage-vcfeval_happy.happy_docker": {
+                    "$dnanexus_link": {
+                        "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+                        "id": "file-GFGbK48433GzV4y54b25p43Z"
+                    }
+                },
+                "stage-vcfeval_happy.reppy_docker": {
+                    "$dnanexus_link": {
+                        "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+                        "id": "file-GFGbK48433Gk4xYG8KK05QqY"
+                    }
+                },
+                "stage-somalier_relate.somalier_docker": {
+                    "$dnanexus_link": {
+                        "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+                        "id": "file-GPQX4G04x14XV5PFfqGkGJk1"
+                    }
+                },
+                "stage-somalier_relate.somalier_extract_file": {
                     "$dnanexus_link": {
                         "analysis": "analysis_1",
-                        "stage": "stage-G5gzP78433GVJ1z1PBKBqxzy",
+                        "stage": "stage-somalier_extract",
                         "field": "somalier_output"
                     }
                 },
-                "stage-G5j1jvj433GYYY25B5jKxFYp.female_threshold": 60,
-                "stage-G5j1jvj433GYYY25B5jKxFYp.male_threshold": 1
-
-            },
-            "output_dirs": {
-                "stage-Fybykxj433GV7vJKFGf3yVkK": "/OUT-FOLDER/STAGE-NAME",
-                "stage-Fq1BPKj433Gx3K4Y8J35j0fv": "/OUT-FOLDER/STAGE-NAME",
-                "stage-G5j1jJj433GpFY3v0JZQ2ZZ0": "/OUT-FOLDER/STAGE-NAME",
-                "stage-G5j1jvj433GYYY25B5jKxFYp": "/OUT-FOLDER/STAGE-NAME"
+                "stage-somalier_relate2multiqc.female_threshold": 60,
+                "stage-somalier_relate2multiqc.male_threshold": 1
             },
             "inputs_filter": {
-                "stage-Fq1BPKj433Gx3K4Y8J35j0fv.query_vcf": [
-                    "NA12878.*"
+                "stage-vcfeval_happy.query_vcf": [
+                    "NA12878.*",
+                    "-[0-9]+Q[0-9]+-"
                 ]
+            },
+            "output_dirs": {
+                "stage-update_runfolders": "/OUT-FOLDER/STAGE-NAME",
+                "stage-vcfeval_happy": "/OUT-FOLDER/STAGE-NAME",
+                "stage-somalier_relate": "/OUT-FOLDER/STAGE-NAME",
+                "stage-somalier_relate2multiqc": "/OUT-FOLDER/STAGE-NAME"
             }
         },
         "app-GF3K4Qj4bJyvpzx055V3G8q7": {
-            "name": "MultiQC",
+            "name": "eggd_MultiQC/2.0.1",
             "details": "",
             "url": "https://github.com/eastgenomics/eggd_multiqc",
             "analysis": "analysis_3",
@@ -118,10 +232,12 @@
             "inputs": {
                 "project_for_multiqc": "INPUT-dx_project_name",
                 "primary_workflow_output": "INPUT-parent_out_dir",
-                "secondary_workflow_output": "/",
-                "calc_custom_coverage": true,
+                "calc_custom_coverage": false,
                 "multiqc_docker": {
-                    "$dnanexus_link": "file-GF3PxgQ433Gqv1Q029Gjzjfv"
+                    "$dnanexus_link": {
+                        "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+                        "id": "file-GF3PxgQ433Gqv1Q029Gjzjfv"
+                    }
                 },
                 "multiqc_config_file": {
                     "$dnanexus_link": "file-G82Y3Kj433GV6bG91pB5VzG0"


### PR DESCRIPTION
# Summary:
- added Epic lab test codes for TWE, in addition to the EGG4 code currently in use
- update dias_single, multi workflows and their inputs
- expanded on executable descriptions

## Changes:
* update dias_single workflow ID
    * update stage-IDs 
    * add all input files (that were removed from the dxworkflow.json and the TWE dias config file)
* update dias_multi workflow ID
    * update stage-IDs
    * add all input files
* update MultiQC input:
    * update config file-ID
