### PR TITLE
Updated to use new Myeloid NovaSeq samples MAF file (haemonc_1706_samples)

### DIFF
--- a/assay_configs/MYE/eggd_conductor_uranus_MYE_config_v1.2.6.json
+++ b/assay_configs/MYE/eggd_conductor_uranus_MYE_config_v1.2.6.json
@@ -2,7 +2,7 @@
     "name": "Config for myeloid assay",
     "assay": "MYE",
     "assay_code": "EGG2|-8128-|-8476-|-5877-",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "details": "Includes main Uranus workflow, multi_fastqc, somalier workflow and multiQC",
     "changelog": {
         "v1.0.0": "Initial working version",
@@ -11,7 +11,8 @@
         "v1.2.1": "Added the new EPIC procedure code to end of assay_code field",
         "v1.2.3": "Updated to use latest ClinVar and COSMIC annotation resource",
         "v1.2.4": "Updated to use ClinVar version 20231112 (hg38)",
-        "v1.2.5": "Updated to use ClinVar version 20231217 and COSMIC v99 (hg38)"
+        "v1.2.5": "Updated to use ClinVar version 20231217 and COSMIC v99 (hg38)",
+        "v1.2.6": "Updated to use new Myeloid NovaSeq samples MAF file (haemonc_1706_samples)"
     },
     "demultiplex": true,
     "users": {
@@ -119,10 +120,10 @@
                     }  
                 ],
                 "stage-eggd_vcf_handler_for_uranus.maf_file": {
-                    "$dnanexus_link": "file-G5PXK90433GjKFq70yfz9qfZ"
+                    "$dnanexus_link": "file-GZJFvq043bFzkk3xBxY6GZyX"
                 },
                 "stage-eggd_vcf_handler_for_uranus.maf_file_tbi": {
-                    "$dnanexus_link": "file-G5PXKFj433Gv495095Z95pk1"
+                    "$dnanexus_link": "file-GZJFvq043bFyG614g32P3K59"
                 },
                 "stage-cgppindel.reference_index": {
                     "$dnanexus_link": {

--- a/assay_configs/MYE/readme.md
+++ b/assay_configs/MYE/readme.md
@@ -46,8 +46,8 @@ Below defines all external input files, their versions and file locations in DNA
 ||`vep_refs`|[Homo_sapiens.GRCh38.dna.toplevel.fa.gz.fai](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/?scope=project&id.values=file-G61yBV8433GjbVj022PyV3K5)|not versioned|
 ||`vep_refs`|[Homo_sapiens.GRCh38.dna.toplevel.fa.gz.gzi](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/?scope=project&id.values=file-G61yBf0433Gp4BBVGj0jxqvP)|not versioned|
 ||`vep_refs`|[homo_sapiens_refseq_vep_103_GRCh38.tar.gz](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/?scope=project&id.values=file-G61yF38433GQgP504Px5PZ4G)|not versioned|
-||`maf_file`|[novaseq_205samples_211007.vcf.gz](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/?scope=project&id.values=file-G5PXK90433GjKFq70yfz9qfZ)| version 211007|
-||`maf_file_tbi`|[novaseq_205samples_211007.vcf.gz.tbi](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/?scope=project&id.values=file-G5PXKFj433Gv495095Z95pk1)| version 211007|
+||`maf_file`|[haemonc_1706_samples.vcf.gz](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/?scope=project&id.values=file-GZJFvq043bFzkk3xBxY6GZyX)|not versioned|
+||`maf_file_tbi`|[haemonc_1706_samples.vcf.gz.tbi](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/?scope=project&id.values=file-GZJFvq043bFyG614g32P3K59)|not versioned|
 
 ---
 


### PR DESCRIPTION
Changes:

• update version from 1.2.5 to 1.2.6
• update version description
• update myeloid novaseq MAF file to haemonc_1706_samples
• update README

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_configs/34)
<!-- Reviewable:end -->
