### PR TITLE
Di 828 twe v2.0.1

### DIFF
--- a/assay_configs/TWE/eggd_conductor_dias_TWE_config_v2.0.1.json
+++ b/assay_configs/TWE/eggd_conductor_dias_TWE_config_v2.0.1.json
@@ -1,6 +1,6 @@
 {
     "name": "Config for Twist whole exome assay",
-    "assay": "TWE",
+    "assay": "TWE38",
     "assay_code": "-EGG4|-9526-|-9688-",
     "version": "2.0.1",
     "details": "Includes main Dias workflows: single, multi and QC reports",

--- a/assay_configs/TWE/eggd_conductor_dias_TWE_config_v2.0.1.json
+++ b/assay_configs/TWE/eggd_conductor_dias_TWE_config_v2.0.1.json
@@ -1,6 +1,7 @@
 {
     "name": "Config for Twist whole exome assay",
     "assay": "TWE38",
+    "genome": "GRCh38",
     "assay_code": "-EGG4|-9526-|-9688-",
     "version": "2.0.1",
     "details": "Includes main Dias workflows: single, multi and QC reports",
@@ -9,7 +10,7 @@
         "v1.1.0": "Updated dias_single and dias_multi workflows, specifying input files",
         "v1.1.1": "Updated somalier genome reference projects",
         "v2.0.0": "Updates to all reference related file to GRCh38",
-        "v2.0.1": "Change vcf_qc input bed to capture bed"
+        "v2.0.1": "Change vcf_qc input bed to capture bed,update instance types,add genome field"
     },
     "demultiplex": true,
     "demultiplex_config": {
@@ -26,6 +27,28 @@
             "analysis": "analysis_1",
             "per_sample": true,
             "process_fastqs": true,
+            "extra_args": {
+                "stageSystemRequirements": {
+                    "stage-sentieon_dnaseq": {
+                        "*": {"instanceType": "mem1_ssd1_v2_x72"}
+                    },
+                    "stage-verifybamid": {
+                        "*": {"instanceType": "mem1_ssd2_v2_x2"}
+                    },
+                    "stage-picardQC": {
+                        "*": {"instanceType": "mem1_ssd2_v2_x4"}
+                    },
+                    "stage-somalier_extract": {
+                        "*": {"instanceType": "mem1_ssd2_v2_x2"}
+                    },
+                    "stage-samtools_flagstat": {
+                        "*": {"instanceType": "mem1_ssd2_v2_x2"}
+                    },
+                    "stage-mosdepth": {
+                        "*": {"instanceType": "mem1_ssd2_v2_x4"}
+                    }
+                }
+            },
             "inputs": {
                 "stage-fastQC.fastqs": "INPUT-R1-R2",
                 "stage-sentieon_dnaseq.sample": "INPUT-SAMPLE-NAME",

--- a/assay_configs/TWE/eggd_conductor_dias_TWE_config_v2.0.1.json
+++ b/assay_configs/TWE/eggd_conductor_dias_TWE_config_v2.0.1.json
@@ -2,13 +2,14 @@
     "name": "Config for Twist whole exome assay",
     "assay": "TWE",
     "assay_code": "-EGG4|-9526-|-9688-",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "details": "Includes main Dias workflows: single, multi and QC reports",
     "changelog": {
         "v1.0.0": "Initial working version",
         "v1.1.0": "Updated dias_single and dias_multi workflows, specifying input files",
         "v1.1.1": "Updated somalier genome reference projects",
-        "v2.0.0": "Updates to all reference related file to GRCh38"
+        "v2.0.0": "Updates to all reference related file to GRCh38",
+        "v2.0.1": "Change vcf_qc input bed to capture bed"
     },
     "demultiplex": true,
     "demultiplex_config": {
@@ -59,7 +60,7 @@
                 "stage-vcfQC.bed_file": {
                     "$dnanexus_link": {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-                        "id": "file-GZYqkkQ4fPQpKYz0BYPZk68j"
+                        "id": "file-G7FK1xQ4kj4317YGFpqYPb75"
                     }
                 },
                 "stage-picardQC.run_CollectMultipleMetrics": false,


### PR DESCRIPTION
- update vcf_qc bed file from exons file to capture file Twist_ComprehensiveExome_targets_hg38_noChr_2020-09.bed
- change assay_code to TWE38 to influence folder creation 
- add genome key and value for future use
- change instance selection for apps (this to be reviewed again for production runs, but for recalling project this set up should speed up per sample)

Running times compared for one sample: 
![image](https://github.com/eastgenomics/eggd_conductor_configs/assets/33088252/5e62fba9-8e88-49b1-9d65-45040aba8e1b)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_configs/38)
<!-- Reviewable:end -->
