### PR TITLE
Update to 1.3.0 and bugfix, eggd_metricsoutput_editor v1.1.0

### DIFF
--- a/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v1.2.1.json
+++ b/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v1.2.1.json
@@ -2,13 +2,14 @@
     "name": "Config for helios workflow for TSO500 assay",
     "assay": "TSO500",
     "assay_code": "EGG6|-8471|-8472|-8475|-9689",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "details": "Includes TSO500 local app only",
     "changelog": {
         "v1.0.0": "Initial working version",
         "v1.0.1": "Add new Epic procedure codes to assay_code field",
         "v1.1.0": "Update eggd_TSO500 v1.2.0 -> v2.0.0",
-        "v1.2.0": "Add eggd_metricsoutput_editor to run after eggd_TSO500"
+        "v1.2.0": "Add eggd_metricsoutput_editor to run after eggd_TSO500",
+        "v1.2.1": "Fix output_dirs for eggd_metricsoutput_editor"
     },
     "demultiplex": false,
     "users": {
@@ -36,7 +37,7 @@
                 "app-GZxvpV845JGGX8K5YGY48BV3": "/OUT-FOLDER/APP-NAME"
             }
         },
-        "app-GgZ3kF04GV07BZ2k5fv3k0Fz": {
+        "app-GjF8gFQ4yyVBg4Y62BV10Vp2": {
             "name": "Eggd MetricsOutput excel maker",
             "details": "Eggd MetricsOutput excel maker",
             "url": "https://github.com/eastgenomics/eggd_MetricsOutput_editor",
@@ -53,7 +54,7 @@
                 }
             },
             "output_dirs": {
-                "app-GgQ84vQ4G7XK0YvYjPJK6yjz": "/OUT-FOLDER/APP-NAME"
+                "app-GjF8gFQ4yyVBg4Y62BV10Vp2": "/OUT-FOLDER/APP-NAME"
             }
         }
     }

--- a/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v1.3.0.json
+++ b/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v1.3.0.json
@@ -9,7 +9,7 @@
         "v1.0.1": "Add new Epic procedure codes to assay_code field",
         "v1.1.0": "Update eggd_TSO500 v1.2.0 -> v2.0.0",
         "v1.2.0": "Add eggd_metricsoutput_editor to run after eggd_TSO500",
-        "v1.2.1": "Fix output_dirs for eggd_metricsoutput_editor"
+        "v1.3.0": "Nadias update, fix output_dirs for eggd_metricsoutput_editor"
     },
     "demultiplex": false,
     "users": {


### PR DESCRIPTION
TSO500 assay config updated to 1.3.0
- Include latest version of eggd_metricsoutput_editor 1.1.0
- Change the output location of eggd_metricsoutput_editor

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_configs/42)
<!-- Reviewable:end -->
