### PR TITLE
Di 805 cen conductor config v1.3.0

### DIFF
--- a/assay_configs/CEN/eggd_conductor_dias_CEN_config_v1.3.0.json
+++ b/assay_configs/CEN/eggd_conductor_dias_CEN_config_v1.3.0.json
@@ -2,13 +2,14 @@
     "name": "Config for CEN assay",
     "assay": "CEN",
     "assay_code": "-EGG5|-9527-|-9617-",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "details": "Includes main Dias workflow, single, multi, QC and reports",
     "changelog": {
         "v1.0.0": "Initial working version",
         "v1.1.0": "Updated dias_single and dias_multi workflows, specifying input files",
         "v1.1.1": "Updated somalier reference genome projects",
-        "v1.2.0": "Updated instance type for MultiQC"
+        "v1.2.0": "Updated instance type for MultiQC",
+        "v1.3.0": "Updated input files for dias_multi and MultiQC"
     },
     "demultiplex": true,
     "users": {
@@ -116,8 +117,8 @@
                 "stage-somalier_extract": "/OUT-FOLDER/STAGE-NAME"
             }
         },
-        "workflow-GV40KG04bz43357995BqBQJY": {
-            "name": "dias_multi_v2.0.0",
+        "workflow-Gj2jP6j4PKbJpVgjK417J4X7": {
+            "name": "dias_multi_v2.2.0",
             "details": "Dias multi workflow - starts Hap.py and somalier_relate jobs",
             "url": "https://github.com/eastgenomics/eggd_dias_multi_workflow",
             "analysis": "analysis_2",
@@ -127,9 +128,6 @@
                 "analysis_1"
             ],
             "inputs": {
-                "stage-update_runfolders.SampleSheet": {
-                    "$dnanexus_link": "INPUT-SAMPLESHEET"
-                },
                 "stage-vcfeval_happy.query_vcf": {
                     "$dnanexus_link": {
                         "analysis": "analysis_1",
@@ -155,16 +153,10 @@
                         "id": "file-FjkzKPQ4yBGgBgJ6KvyZ563P"
                     }
                 },
-                "stage-vcfeval_happy.reference_fasta": {
+                "stage-vcfeval_happy.reference_fasta_tar": {
                     "$dnanexus_link": {
                         "project": "project-F3zxk7Q4F30Xp8fG69K1Vppj",
-                        "id": "file-F403K904F30y2vpVFqxB9kz7"
-                    }
-                },
-                "stage-vcfeval_happy.reference_fasta_index": {
-                    "$dnanexus_link": {
-                        "project": "project-F3zxk7Q4F30Xp8fG69K1Vppj",
-                        "id": "file-F3zyVj84F30jxYxG68vJyg68"
+                        "id": "file-F3zxG0Q4fXX9YFjP1v5jK9jf"
                     }
                 },
                 "stage-vcfeval_happy.reference_sdf_tar": {
@@ -208,7 +200,6 @@
                 ]
             },
             "output_dirs": {
-                "stage-update_runfolders": "/OUT-FOLDER/STAGE-NAME",
                 "stage-vcfeval_happy": "/OUT-FOLDER/STAGE-NAME",
                 "stage-somalier_relate": "/OUT-FOLDER/STAGE-NAME",
                 "stage-somalier_relate2multiqc": "/OUT-FOLDER/STAGE-NAME"
@@ -235,11 +226,11 @@
                 "multiqc_docker": {
                     "$dnanexus_link": {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-                        "id": "file-GF3PxgQ433Gqv1Q029Gjzjfv"
+                        "id": "file-Gj22pvQ433Gk8Y6JJXy5J73Y"
                     }
                 },
                 "multiqc_config_file": {
-                    "$dnanexus_link": "file-GV55qpj47f086YFQb47B5Gg4"
+                    "$dnanexus_link": "file-Gj81GKQ46f9Kgb0fPB56Jzkk"
                 }
             },
             "output_dirs": {

--- a/assay_configs/CEN/eggd_conductor_dias_CEN_config_v1.3.0.json
+++ b/assay_configs/CEN/eggd_conductor_dias_CEN_config_v1.3.0.json
@@ -155,7 +155,7 @@
                 },
                 "stage-vcfeval_happy.reference_fasta_tar": {
                     "$dnanexus_link": {
-                        "project": "project-F3zxk7Q4F30Xp8fG69K1Vppj",
+                        "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
                         "id": "file-F3zxG0Q4fXX9YFjP1v5jK9jf"
                     }
                 },


### PR DESCRIPTION
Changes

- dias_multi_workflow:

  - updated workflow ID from workflow-GV40KG04bz43357995BqBQJY to workflow-Gj2jP6j4PKbJpVgjK417J4X7

  - updated workflow name from dias_multi_v2.0.0 to dias_multi_v2.2.0

  - removed stage-update_runfolders from inputs and output_dirs

  - updated stage-vcfeval_happy to reference  eggd_vcfeval_hap.py fasta_tar which contains both fasta and index files as a single input  rather than referring to both files as separate inputs

- eggd_MultiQC:

  - updated multiqc_docker file ID from file-GF3PxgQ433Gqv1Q029Gjzjfv to file-Gj22pvQ433Gk8Y6JJXy5J73Y

  - updated multiqc_config file ID from file-GV55qpj47f086YFQb47B5Gg4 to file-Gj81GKQ46f9Kgb0fPB56Jzkk

    -Updated changelog

- Renamed config file from eggd_conductor_dias_CEN_config_v1.2.0.json to eggd_conductor_dias_CEN_config_v1.3.0.json

Example conductor job: https://platform.dnanexus.com/panx/projects/GjGKq2047g7K915jP8Z6PBz5/monitor/job/GjGfbZQ47g788vbQ3G71PQGp

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_configs/45)
<!-- Reviewable:end -->
