### PR TITLE
updated to use clinvar v20240514 (hg38)

### DIFF
--- a/assay_configs/MYE/eggd_conductor_uranus_MYE_config_v1.3.3.json
+++ b/assay_configs/MYE/eggd_conductor_uranus_MYE_config_v1.3.3.json
@@ -2,7 +2,7 @@
     "name": "Config for myeloid assay",
     "assay": "MYE",
     "assay_code": "EGG2|-8128-|-8476-|-5877-",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "details": "Includes main Uranus workflow, multi_fastqc, somalier workflow and multiQC",
     "changelog": {
         "v1.0.0": "Initial working version",
@@ -18,7 +18,8 @@
         "v1.2.9": "Updated to use ClinVar version 20240317 (hg38)",
         "v1.3.0": "Updated main workflow to v1.13.0 (addition of eggd_apheleia app)",
         "v1.3.1": "Updated main workflow to v1.13.1 (eggd_apheleia v1.0.1)",
-        "v1.3.2": "Updated to use ClinVar version 20240407 (hg38)"
+        "v1.3.2": "Updated to use ClinVar version 20240407 (hg38)",
+        "v1.3.3": "Updated to use ClinVar version 20240514 (hg38)"
     },
     "demultiplex": true,
     "users": {
@@ -95,10 +96,10 @@
                 ],
                 "stage-eggd_vcf_handler_for_uranus.vep_annotation": [
                     {
-                      "$dnanexus_link": "file-GjP2v0j42VYfY5qfYGVKxy79"
+                      "$dnanexus_link": "file-Gk5VfVQ42VYfZvyPfb3959g2"
                     },
                     {
-                      "$dnanexus_link": "file-GjP2vG842VYjBz0VfGQBZ7F8"
+                      "$dnanexus_link": "file-Gk5VfYQ42VYVGy10zVkxf1Ff"
                     },
                     {
                       "$dnanexus_link": "file-G61xbP0433GqX36p8QQxP3PV"

--- a/assay_configs/MYE/readme.md
+++ b/assay_configs/MYE/readme.md
@@ -29,8 +29,8 @@ Below defines all external input files, their versions and file locations in DNA
 ||`pkrusche_`<br>`happy_docker`|[pkrusche_happy_v0.3.9.tar.gz](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/?scope=project&id.values=file-GFGbK48433GzV4y54b25p43Z)|v0.3.9|
 |[eggd_vcf_handler<br>_for_uranus](https://github.com/eastgenomics/eggd_vcf_handler_for_uranus)|`mutect2_bed`|[coding_unrestricted_GRCh38_myeloid_5bp_flank_v2.0.0.bed](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/?scope=project&id.values=file-G9vKbv0433Gg2bP9GP72pxKJ)|v2.0.0|
 ||`pindel_bed`|[pindel_cgppindel_filtering_coordinates_v1.0.bed](https://platform.dnanexus.com/panx/projects/G21BGP84q5JFYf168QjZ58Vz/data/?scope=project&id.values=file-G0bFvXQ433GZJq780QgxZxKf)|v1.0|
-||`vep_annotation`|[clinvar_20240407_hg38_withchr.vcf.gz](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/annotation/b38/clinvar)|version 20240407|
-||`vep_annotation`|[clinvar_20240407_hg38_withchr.vcf.gz.tbi](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/annotation/b38/clinvar)|version 20240407|
+||`vep_annotation`|[clinvar_20240514_hg38_withchr.vcf.gz](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/annotation/b38/clinvar)|version 20240407|
+||`vep_annotation`|[clinvar_20240514_hg38_withchr.vcf.gz.tbi](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/annotation/b38/clinvar)|version 20240407|
 ||`vep_refs`|[gnomad.genomes.r3.0.indel.tsv.gz](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/?scope=project&id.values=file-G61xbP0433GqX36p8QQxP3PV)|version r3.0|
 ||`vep_refs`|[gnomad.genomes.r3.0.indel.tsv.gz.tbi](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/?scope=project&id.values=file-G61xf3j433Gz49jf6XjKG4F0)|version r3.0|
 ||`vep_refs`|[whole_genome_SNVs.tsv.gz](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/?scope=project&id.values=file-G61xfZ0433Gj2vJ7P8k9ky2Z)| not versioned|


### PR DESCRIPTION
Changes:
- Renamed config file from eggd_conductor_uranus_MYE_config_v1.3.2.json to eggd_conductor_uranus_MYE_config_v1.3.3.json

- Increment version from 1.3.2 to 1.3.3

- Added Changelog for v1.3.3

- Updated ClinVar GRCh38 annotation resource files to version 20240514

  - clinvar_20240514_hg38_withchr.vcf.gz (file-Gk5VfVQ42VYfZvyPfb3959g2)

  - clinvar_20240514_hg38_withchr.vcf.gz.tbi (file-Gk5VfYQ42VYVGy10zVkxf1Ff)

- README.md updated to reference correct versions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_configs/58)
<!-- Reviewable:end -->
