### PR TITLE
updated to use clinvar v20240611 (hg38) MYE

### DIFF
--- a/assay_configs/MYE/eggd_conductor_uranus_MYE_config_v2.0.1.json
+++ b/assay_configs/MYE/eggd_conductor_uranus_MYE_config_v2.0.1.json
@@ -20,7 +20,8 @@
         "v1.3.1": "Updated main workflow to v1.13.1 (eggd_apheleia v1.0.1)",
         "v1.3.2": "Updated to use ClinVar version 20240407 (hg38)",
         "v1.3.3": "Updated to use ClinVar version 20240514 (hg38)",
-        "v2.0.0": "Updated main workflow to 2.0.0; update ref genome and resource files"
+        "v2.0.0": "Updated main workflow to 2.0.0; update ref genome and resource files",
+        "v2.0.1": "Updated to use ClinVar version 20240611 (hg38)"
     },
     "demultiplex": true,
     "users": {
@@ -116,10 +117,10 @@
                 ],
                 "stage-eggd_vcf_handler_for_uranus.vep_annotation": [
                     {
-                      "$dnanexus_link": "file-Gk5fxz847zgJ830X8b2b12zX"
+                      "$dnanexus_link": "file-Gk5VfVQ42VYfZvyPfb3959g2"
                     },
                     {
-                      "$dnanexus_link": "file-Gk5g01j475vQ8Py2Yp66PbXq"
+                      "$dnanexus_link": "file-Gk5VfYQ42VYVGy10zVkxf1Ff"
                     },
                     {
                       "$dnanexus_link": "file-G61xbP0433GqX36p8QQxP3PV"

--- a/assay_configs/MYE/eggd_conductor_uranus_MYE_config_v2.0.1.json
+++ b/assay_configs/MYE/eggd_conductor_uranus_MYE_config_v2.0.1.json
@@ -117,10 +117,10 @@
                 ],
                 "stage-eggd_vcf_handler_for_uranus.vep_annotation": [
                     {
-                      "$dnanexus_link": "file-Gk5VfVQ42VYfZvyPfb3959g2"
+                      "$dnanexus_link": "file-Gkj3VKQ444xgJ8FK4KzFz9v7"
                     },
                     {
-                      "$dnanexus_link": "file-Gk5VfYQ42VYVGy10zVkxf1Ff"
+                      "$dnanexus_link": "file-Gkj3VJj4Q19zg8BXf7QB1XGB"
                     },
                     {
                       "$dnanexus_link": "file-G61xbP0433GqX36p8QQxP3PV"

--- a/assay_configs/MYE/readme.md
+++ b/assay_configs/MYE/readme.md
@@ -31,8 +31,8 @@ Below defines all external input files, their versions and file locations in DNA
 ||`pkrusche_`<br>`happy_docker`|[pkrusche_happy_v0.3.9.tar.gz](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/?scope=project&id.values=file-GFGbK48433GzV4y54b25p43Z)|v0.3.9|
 |[eggd_vcf_handler<br>_for_uranus](https://github.com/eastgenomics/eggd_vcf_handler_for_uranus)|`mutect2_bed`|[coding_unrestricted_GRCh38_myeloid_5bp_flank_v2.1.0.bed](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/?scope=project&id.values=file-Gj6YQg84qv8fkGzygZ19j300)|v2.1.0|
 ||`pindel_bed`|[pindel_cgppindel_filtering_coordinates_v1.1.bed](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/?scope=project&id.values=file-Gj6YXj84qv8YV5Z3yb2Zk6Pg)|v1.1|
-||`vep_annotation`|[clinvar_20240514_GRCh38.vcf.gz](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/annotation/b38/clinvar)|version 20240514|
-||`vep_annotation`|[clinvar_20240514_GRCh38.vcf.gz.tbi](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/annotation/b38/clinvar)|version 20240514|
+||`vep_annotation`|[clinvar_20240611_GRCh38.vcf.gz](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/annotation/b38/clinvar)|version 20240611|
+||`vep_annotation`|[clinvar_20240611_GRCh38.vcf.gz.tbi](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/annotation/b38/clinvar)|version 20240611|
 ||`vep_refs`|[gnomad.genomes.r3.0.indel.tsv.gz](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/?scope=project&id.values=file-G61xbP0433GqX36p8QQxP3PV)|version r3.0|
 ||`vep_refs`|[gnomad.genomes.r3.0.indel.tsv.gz.tbi](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/?scope=project&id.values=file-G61xf3j433Gz49jf6XjKG4F0)|version r3.0|
 ||`vep_refs`|[whole_genome_SNVs.tsv.gz](https://platform.dnanexus.com/panx/projects/Fkb6Gkj433GVVvj73J7x8KbV/data/?scope=project&id.values=file-G61xfZ0433Gj2vJ7P8k9ky2Z)| not versioned|


### PR DESCRIPTION
Changes:
- Renamed config file from eggd_conductor_uranus_MYE_config_v2.0.0.json to eggd_conductor_uranus_MYE_config_v2.0.1.json by git mv
- Increment version from 2.0.0 to 2.0.1
- Added Changelog for v2.0.1
- Updated ClinVar GRCh38 annotation resource files to version 20240514 
  - clinvar_20240611_hg38.vcf.gz (file-Gkj3VKQ444xgJ8FK4KzFz9v7) 
  - clinvar_20240611_hg38.vcf.gz.tbi (file-Gkj3VJj4Q19zg8BXf7QB1XGB)
- README.md updated to reference correct versions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_configs/64)
<!-- Reviewable:end -->
