### PR TITLE
Updated to use latest clinvar resource files

### DIFF
--- a/assay_configs/MYE/eggd_conductor_uranus_MYE_config_v2.0.2.json
+++ b/assay_configs/MYE/eggd_conductor_uranus_MYE_config_v2.0.2.json
@@ -2,7 +2,7 @@
     "name": "Config for myeloid assay",
     "assay": "MYE",
     "assay_code": "EGG2|-8128-|-8476-|-5877-",
-    "version": "2.0.0",
+    "version": "2.0.2",
     "details": "Includes main Uranus workflow, multi_fastqc, somalier workflow and multiQC",
     "changelog": {
         "v1.0.0": "Initial working version",
@@ -21,7 +21,8 @@
         "v1.3.2": "Updated to use ClinVar version 20240407 (hg38)",
         "v1.3.3": "Updated to use ClinVar version 20240514 (hg38)",
         "v2.0.0": "Updated main workflow to 2.0.0; update ref genome and resource files",
-        "v2.0.1": "Updated to use ClinVar version 20240611 (hg38)"
+        "v2.0.1": "Updated to use ClinVar version 20240611 (hg38)",
+        "v2.0.2": "Updated to use ClinVar version 20240708 (hg38)"
     },
     "demultiplex": true,
     "users": {
@@ -117,10 +118,10 @@
                 ],
                 "stage-eggd_vcf_handler_for_uranus.vep_annotation": [
                     {
-                      "$dnanexus_link": "file-Gkj3VKQ444xgJ8FK4KzFz9v7"
+                      "$dnanexus_link": "file-GpBKp484bJ6qKK96bPpFz5qz"
                     },
                     {
-                      "$dnanexus_link": "file-Gkj3VJj4Q19zg8BXf7QB1XGB"
+                      "$dnanexus_link": "file-GpBKx804J7Q3kjg5pZpB4gX0"
                     },
                     {
                       "$dnanexus_link": "file-G61xbP0433GqX36p8QQxP3PV"


### PR DESCRIPTION
-Renamed file for version 2.0.2
-Increment version from 2.0.1 to 2.0.2
-Added Changelog for v2.0.2
-Updated ClinVar GRCh38 annotation resource files to version 20240708

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_configs/67)
<!-- Reviewable:end -->
