### PR TITLE
updated reference to rescue_vcf pointing to new VCF

### DIFF
--- a/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.1.1.json
+++ b/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.1.1.json
@@ -138,7 +138,7 @@
                 "stage-vcf_rescue.rescue_vcf": {
                     "$dnanexus_link": {
                       "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-                      "id": "file-Gp7vg9j4949f62X9b2Q9zxJY"
+                      "id": "file-GpVgQk04949qzzZk4FJ0ZQp7"
                     }
                   },
                 "stage-vcf_rescue.rescue_non_pass": true,


### PR DESCRIPTION
Updated rescue VCF reference to point to following file:

```
dx describe project-Fkb6Gkj433GVVvj73J7x8KbV:file-GpVgQk04949qzzZk4FJ0ZQp7
Result 1:
ID                    file-GpVgQk04949qzzZk4FJ0ZQp7
Class                 file
Project               project-Fkb6Gkj433GVVvj73J7x8KbV
Folder                /annotation/b37/OPA
Name                  240711_TSO500_hotspot_rescue.vcf.gz
State                 closed
Visibility            visible
Types                 -
Properties            -
Tags                  -
Outgoing links        -
Created               Fri Jul 26 11:20:20 2024
Created by            spaul4
Last modified         Tue Jul 30 10:32:40 2024
Media type            application/x-gzip
archivalState         "live"
Size                  131.98 KB
cloudAccount          "cloudaccount-dnanexus"
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_configs/70)
<!-- Reviewable:end -->
