### PR TITLE
Update TSO500 vep config to v1.2.13

### DIFF
--- a/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.2.4.json
+++ b/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.2.4.json
@@ -18,7 +18,7 @@
         "v2.2.0": "Incorporate eggd_MetricsOutput_MultiQC_parser, Update to latest TSO500 vep config file (v1.2.11)",
         "v2.2.1": "Update to latest TSO500 VEP transcript list (v1.3.0)",
         "v2.2.2": "Add new Epic assay codes to assay_code field",
-        "v2.2.3": "Update to latest TSO500 vep config file (v1.2.12)"
+        "v2.2.3": "Update to latest TSO500 vep config file (v1.2.12)",
 	"v2.2.4": "Update to latest TSO500 vep config file (v1.2.13)"
     },
     "demultiplex": true,    

--- a/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.2.4.json
+++ b/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.2.4.json
@@ -2,7 +2,7 @@
     "name": "Config for Helios pipeline with TSO500 assay",
     "assay": "TSO500",
     "assay_code": "-8471|-8472|-8475|-9689|-10011|-10012|-10040|-10041|-10042|-10043",
-    "version": "2.2.3",
+    "version": "2.2.4",
     "details": "Allocates more storage for the eggd_tso500 app output",
     "changelog": {
         "v1.0.0": "Initial working version",
@@ -19,6 +19,7 @@
         "v2.2.1": "Update to latest TSO500 VEP transcript list (v1.3.0)",
         "v2.2.2": "Add new Epic assay codes to assay_code field",
         "v2.2.3": "Update to latest TSO500 vep config file (v1.2.12)"
+	"v2.2.4": "Update to latest TSO500 vep config file (v1.2.13)"
     },
     "demultiplex": true,    
     "demultiplex_config": {
@@ -171,7 +172,7 @@
                 "stage-vep.config_file": {
                     "$dnanexus_link": {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-                        "id": "file-GvJ326Q40P98VVXjv8BGfybx"
+                        "id": "file-Gx2k6gQ40P9Pyg59y42XJQj0"
                     }
                 },
                 "stage-vep.transcript_list": {


### PR DESCRIPTION
Changes:

    Update config version number to v2.2.4
    Update changelog
    Update VEP config file ID to TSO500 VEP config v1.2.13

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_configs/88)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated to version 2.2.4 of the Helios pipeline configuration for the TSO500 assay.
	- Added a changelog entry detailing the update to the latest TSO500 VEP config file (version v1.2.13).
	- Changed the input ID for the VEP config file to enhance compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->