### PR TITLE
v2.3.0: Add eggd_ici_uploader to workflow - BunnyNo

### DIFF
--- a/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.3.0.json
+++ b/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.3.0.json
@@ -2,7 +2,7 @@
     "name": "Config for Helios pipeline with TSO500 assay",
     "assay": "TSO500",
     "assay_code": "-8471|-8472|-8475|-9689|-10011|-10012|-10040|-10041|-10042|-10043",
-    "version": "2.2.3",
+    "version": "2.3.0",
     "details": "Allocates more storage for the eggd_tso500 app output",
     "changelog": {
         "v1.0.0": "Initial working version",
@@ -18,7 +18,8 @@
         "v2.2.0": "Incorporate eggd_MetricsOutput_MultiQC_parser, Update to latest TSO500 vep config file (v1.2.11)",
         "v2.2.1": "Update to latest TSO500 VEP transcript list (v1.3.0)",
         "v2.2.2": "Add new Epic assay codes to assay_code field",
-        "v2.2.3": "Update to latest TSO500 vep config file (v1.2.12)"
+        "v2.2.3": "Update to latest TSO500 vep config file (v1.2.12)",
+        "v2.3.0": "Update to use app-eggd_ici_uploader/v1.0.0"
     },
     "demultiplex": true,    
     "demultiplex_config": {

--- a/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.3.0.json
+++ b/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.3.0.json
@@ -58,6 +58,22 @@
                 "app-GgBKy7j4QjX77XK69fG7Pj0y": "/OUT-FOLDER/APP-NAME"
             }
         },
+        "app-Gvb47584ZGzp4pF9Gpk10P9Q": {
+            "name": "eggd-ici_uploader/v1.0.0",
+            "details": "ICI run uploader",
+            "url": "https://github.com/eastgenomics/eggd_ici_uploader",
+            "analysis": "ici_upload",
+            "per_sample": false,
+            "process_fastqs": false,
+            "depends_on": ["analysis_1"],
+            "inputs": {
+                "run_folder": "INPUT-analysis_1-out-dir",
+                "workflow_id": "c209834d-92d5-445f-b89b-c4d291c57613",
+                "api_key_file": {
+                    "$dnanexus_link": "file-12345abcdevwxyz"
+                }
+            }
+        },
         "applet-FvyXygj433GbKPPY0QY8ZKQG": {
             "name": "multi_fastqc_v1.1.0",
             "details": "Takes all fastqs of all samples, starts one job which runs fastqc in sub jobs for each fastq",

--- a/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.3.0.json
+++ b/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.3.0.json
@@ -80,7 +80,7 @@
                 "api_key_file": {
                     "$dnanexus_link": {
                         "project": "project-Fv7VVv04FjKB44KJ3fp9554Q",
-                        "id": "file-Gx4v4g04FjK6F3fkGKJK3Y3J"
+                        "id": "file-Gy3q4Z049YxFq9p4q9788V5y"
                     }
                 }
             },

--- a/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.3.0.json
+++ b/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.3.0.json
@@ -70,6 +70,10 @@
             "per_sample": false,
             "process_fastqs": false,
             "depends_on": ["analysis_1"],
+            "extra_args": {
+                "systemRequirements": {"*": {"instanceType": "mem2_ssd1_v2_x16"}},
+                "priority": "high"
+            },
             "inputs": {
                 "run_folder": "INPUT-analysis_1-out_dir",
                 "workflow_id": "c209834d-92d5-445f-b89b-c4d291c57613",

--- a/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.3.0.json
+++ b/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.3.0.json
@@ -69,11 +69,16 @@
             "process_fastqs": false,
             "depends_on": ["analysis_1"],
             "inputs": {
-                "run_folder": "INPUT-analysis_1-out-dir",
+                "run_folder": "INPUT-analysis_1-out_dir",
                 "workflow_id": "c209834d-92d5-445f-b89b-c4d291c57613",
                 "api_key_file": {
-                    "$dnanexus_link": "project-Fv7VVv04FjKB44KJ3fp9554Q:file-Gx4v4g04FjK6F3fkGKJK3Y3J"
+                    "$dnanexus_link": {
+                        "project": "project-Fv7VVv04FjKB44KJ3fp9554Q",
+                        "id": "file-Gx4v4g04FjK6F3fkGKJK3Y3J"
+                    }
                 }
+            },
+            "output_dirs": {
             }
         },
         "applet-FvyXygj433GbKPPY0QY8ZKQG": {

--- a/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.3.0.json
+++ b/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.3.0.json
@@ -71,7 +71,7 @@
                 "run_folder": "INPUT-analysis_1-out-dir",
                 "workflow_id": "c209834d-92d5-445f-b89b-c4d291c57613",
                 "api_key_file": {
-                    "$dnanexus_link": "file-12345abcdevwxyz"
+                    "$dnanexus_link": "project-Fv7VVv04FjKB44KJ3fp9554Q:file-Gx4v4g04FjK6F3fkGKJK3Y3J"
                 }
             }
         },


### PR DESCRIPTION
Adding eggd_ici_uploader to the workflow. Full of edits:

- Added entry for eggd_ici_uploader
    - dependency on eggd_tso500 output; is independent of remaining workflow
- incremented version and changelong

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_configs/90)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated configuration for the Helios pipeline to version 2.3.0, enhancing functionality with the addition of the ICI run uploader.
	- Introduced a new executable entry for the `eggd-ici_uploader/v1.0.0`, detailing required inputs for operation.

- **Changelog Updates**
	- Added changelog entry for version 2.3.0 to reflect recent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->