### PR TITLE
DI-1028 TWE GRCh38 v2.1.0 - BunnyNo

### DIFF
--- a/assay_configs/TWE/eggd_conductor_dias_TWE_config_v2.1.0.json
+++ b/assay_configs/TWE/eggd_conductor_dias_TWE_config_v2.1.0.json
@@ -260,7 +260,7 @@
                 "multiqc_config_file": {
                     "$dnanexus_link":  {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-                        "id": "file-Gx9Gy2046J883j8PY58V9Vp8"
+                        "id": "file-GxQ342j46J8J4pJ3fJ60qKky"
                     }
                 }
             },

--- a/assay_configs/TWE/eggd_conductor_dias_TWE_config_v2.1.0.json
+++ b/assay_configs/TWE/eggd_conductor_dias_TWE_config_v2.1.0.json
@@ -3,14 +3,15 @@
     "assay": "TWE38",
     "genome": "GRCh38",
     "assay_code": "-EGG4|-9526-|-9688-",
-    "version": "2.0.1",
+    "version": "2.1.0",
     "details": "Includes main Dias workflows: single, multi and QC reports",
     "changelog": {
         "v1.0.0": "Initial working version",
         "v1.1.0": "Updated dias_single and dias_multi workflows, specifying input files",
         "v1.1.1": "Updated somalier genome reference projects",
         "v2.0.0": "Updates to all reference related file to GRCh38",
-        "v2.0.1": "Change vcf_qc input bed to capture bed,update instance types,add genome field"
+        "v2.0.1": "Change vcf_qc input bed to capture bed,update instance types,add genome field",
+        "v2.1.0": "TO BE ADDED"
     },
     "demultiplex": true,
     "demultiplex_config": {
@@ -20,9 +21,9 @@
         "org-emee_1": "CONTRIBUTE"
     },
     "executables": {
-        "workflow-GbXF3bQ4zbvBzjg4j6884z3g": {
-            "name": "dias_single_v2.2.0",
-            "details": "Dias single workflow - Runs Sentieon, multi_fastqc, verifyBAM_ID, vcf_QC, flagstat, Picard, mosdepth, somalier extract using the fastqs out of demultiplexing step",
+        "workflow-Gkj2pgj4B1BxKfPZBfy85FjX": {
+            "name": "dias_single_v2.5.0",
+            "details": "Dias single workflow - Runs Sentieon, multi_fastqc, verifyBAM_ID, vcf_QC, flagstat, Picard, mosdepth, somalier extract using the fastqs out of demultiplexing step and eggd_sex_check",
             "url": "https://github.com/eastgenomics/eggd_dias_single_workflow",
             "analysis": "analysis_1",
             "per_sample": true,
@@ -118,7 +119,9 @@
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
                         "id": "file-G7FJjz04kj424vq826gKbZx7"
                     }
-                }
+                },
+                "stage-sex_check.male_threshold": "TO BE REVIEWED",
+                "stage-sex_check.female_threshold": "TO BE REVIEWED"
             },
             "output_dirs": {
                 "stage-fastQC": "/OUT-FOLDER/STAGE-NAME",
@@ -131,8 +134,8 @@
                 "stage-somalier_extract": "/OUT-FOLDER/STAGE-NAME"
             }
         },
-        "workflow-GZFB75j4kYX4k6jfG3f9p3XX": {
-            "name": "dias_multi_v2.1.0",
+        "workflow-Gj2jP6j4PKbJpVgjK417J4X7": {
+            "name": "dias_multi_v2.2.0",
             "details": "Dias multi workflow - starts Hap.py and somalier_relate jobs",
             "url": "https://github.com/eastgenomics/eggd_dias_multi_workflow",
             "analysis": "analysis_2",
@@ -217,7 +220,6 @@
                 ]
             },
             "output_dirs": {
-                "stage-update_runfolders": "/OUT-FOLDER/STAGE-NAME",
                 "stage-vcfeval_happy": "/OUT-FOLDER/STAGE-NAME",
                 "stage-somalier_relate": "/OUT-FOLDER/STAGE-NAME",
                 "stage-somalier_relate2multiqc": "/OUT-FOLDER/STAGE-NAME"
@@ -250,7 +252,7 @@
                 "multiqc_config_file": {
                     "$dnanexus_link":  {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-                        "id": "file-GV8KZp04FfpQ7JPzzBbGXX2x"
+                        "id": "TO BE UPDATED"
                     }
                 }
             },

--- a/assay_configs/TWE/eggd_conductor_dias_TWE_config_v2.1.0.json
+++ b/assay_configs/TWE/eggd_conductor_dias_TWE_config_v2.1.0.json
@@ -153,9 +153,6 @@
                 "analysis_1"
             ],
             "inputs": {
-                "stage-update_runfolders.SampleSheet": {
-                    "$dnanexus_link": "INPUT-SAMPLESHEET"
-                },
                 "stage-vcfeval_happy.query_vcf": {
                     "$dnanexus_link": {
                         "analysis": "analysis_1",

--- a/assay_configs/TWE/eggd_conductor_dias_TWE_config_v2.1.0.json
+++ b/assay_configs/TWE/eggd_conductor_dias_TWE_config_v2.1.0.json
@@ -9,9 +9,12 @@
         "v1.0.0": "Initial working version",
         "v1.1.0": "Updated dias_single and dias_multi workflows, specifying input files",
         "v1.1.1": "Updated somalier genome reference projects",
+        "v1.2.0": "Updated input files for dias_multi and MultiQC",
+        "v1.3.0": "Updated workflow ID and name for dias_single",
+        "v1.4.0": "Updated dias_single to 2.5.0 and multiqc config to v2.3.0",
         "v2.0.0": "Updates to all reference related file to GRCh38",
         "v2.0.1": "Change vcf_qc input bed to capture bed,update instance types,add genome field",
-        "v2.1.0": "TO BE ADDED"
+        "v2.1.0": "Updates dias_single to v2.7.0, Sentieon instance type, sex check thresholds and adds mosdepth docker input. Updates dias_multi to v2.2.0 and removes references to update_run_folders. Updates egg_multiqc to v2.02, MultiQC docker input to v1.14 and MultiQC config for GRCh38"
     },
     "demultiplex": true,
     "demultiplex_config": {
@@ -21,9 +24,9 @@
         "org-emee_1": "CONTRIBUTE"
     },
     "executables": {
-        "workflow-Gkj2pgj4B1BxKfPZBfy85FjX": {
-            "name": "dias_single_v2.5.0",
-            "details": "Dias single workflow - Runs Sentieon, multi_fastqc, verifyBAM_ID, vcf_QC, flagstat, Picard, mosdepth, somalier extract using the fastqs out of demultiplexing step and eggd_sex_check",
+        "workflow-Gx44P1j46vxPgz7BbQ81VXJ3": {
+            "name": "dias_single_v2.7.0",
+            "details": "Dias single workflow - Runs Sentieon, multi_fastqc, verifyBAMID, vcf_QC, flagstat, Picard, mosdepth, somalier extract using the fastqs out of demultiplexing step, and eggd_sex_check",
             "url": "https://github.com/eastgenomics/eggd_dias_single_workflow",
             "analysis": "analysis_1",
             "per_sample": true,
@@ -31,7 +34,7 @@
             "extra_args": {
                 "stageSystemRequirements": {
                     "stage-sentieon_dnaseq": {
-                        "*": {"instanceType": "mem1_ssd1_v2_x72"}
+                        "*": {"instanceType": "mem1_ssd1_v2_x36"}
                     },
                     "stage-verifybamid": {
                         "*": {"instanceType": "mem1_ssd2_v2_x2"}
@@ -127,8 +130,8 @@
                         "id": "file-G7FJjz04kj424vq826gKbZx7"
                     }
                 },
-                "stage-sex_check.male_threshold": "TO BE REVIEWED",
-                "stage-sex_check.female_threshold": "TO BE REVIEWED"
+                "stage-sex_check.male_threshold": 4.00,
+                "stage-sex_check.female_threshold": 5.00
             },
             "output_dirs": {
                 "stage-fastQC": "/OUT-FOLDER/STAGE-NAME",
@@ -230,8 +233,8 @@
                 "stage-somalier_relate2multiqc": "/OUT-FOLDER/STAGE-NAME"
             }
         },
-        "app-GF3K4Qj4bJyvpzx055V3G8q7": {
-            "name": "eggd_MultiQC/2.0.1",
+        "app-Gjyybj844V5bbzXQVfk32Xby": {
+            "name": "eggd_MultiQC/2.0.2",
             "details": "",
             "url": "https://github.com/eastgenomics/eggd_multiqc",
             "analysis": "analysis_3",
@@ -257,12 +260,12 @@
                 "multiqc_config_file": {
                     "$dnanexus_link":  {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-                        "id": "TO BE UPDATED"
+                        "id": "file-Gx9Gy2046J883j8PY58V9Vp8"
                     }
                 }
             },
             "output_dirs": {
-                "app-GF3K4Qj4bJyvpzx055V3G8q7": "/OUT-FOLDER/APP-NAME"
+                "app-Gjyybj844V5bbzXQVfk32Xby": "/OUT-FOLDER/APP-NAME"
             }
         }
     }

--- a/assay_configs/TWE/eggd_conductor_dias_TWE_config_v2.1.0.json
+++ b/assay_configs/TWE/eggd_conductor_dias_TWE_config_v2.1.0.json
@@ -1,6 +1,6 @@
 {
     "name": "Config for Twist whole exome assay",
-    "assay": "TWE",
+    "assay": "38_TWE",
     "genome": "GRCh38",
     "assay_code": "-EGG4|-9526-|-9688-",
     "version": "2.1.0",

--- a/assay_configs/TWE/eggd_conductor_dias_TWE_config_v2.1.0.json
+++ b/assay_configs/TWE/eggd_conductor_dias_TWE_config_v2.1.0.json
@@ -1,6 +1,6 @@
 {
     "name": "Config for Twist whole exome assay",
-    "assay": "TWE38",
+    "assay": "TWE",
     "genome": "GRCh38",
     "assay_code": "-EGG4|-9526-|-9688-",
     "version": "2.1.0",
@@ -90,6 +90,7 @@
                 "stage-picardQC.run_CollectMultipleMetrics": false,
                 "stage-picardQC.run_CollectHsMetrics": true,
                 "stage-picardQC.run_CollectTargetedPcrMetrics": false,
+                "stage-picardQC.run_CollectRnaSeqMetrics": false,
                 "stage-picardQC.fasta_index": {
                     "$dnanexus_link": {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
@@ -100,6 +101,12 @@
                     "$dnanexus_link": {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
                         "id": "file-G7FK1xQ4kj4317YGFpqYPb75"
+                    }
+                },
+                "stage-mosdepth.mosdepth_docker": {
+                    "$dnanexus_link": {
+                        "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+                        "id": "file-GbJXzq04pgpY6FX22Qvk9F9x"
                     }
                 },
                 "stage-somalier_extract.somalier_docker": {
@@ -131,7 +138,8 @@
                 "stage-samtools_flagstat": "/OUT-FOLDER/STAGE-NAME",
                 "stage-picardQC": "/OUT-FOLDER/STAGE-NAME",
                 "stage-mosdepth": "/OUT-FOLDER/STAGE-NAME",
-                "stage-somalier_extract": "/OUT-FOLDER/STAGE-NAME"
+                "stage-somalier_extract": "/OUT-FOLDER/STAGE-NAME",
+                "stage-sex_check": "/OUT-FOLDER/STAGE-NAME"
             }
         },
         "workflow-Gj2jP6j4PKbJpVgjK417J4X7": {
@@ -246,7 +254,7 @@
                 "multiqc_docker": {
                     "$dnanexus_link": {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-                        "id": "file-GF3PxgQ433Gqv1Q029Gjzjfv"
+                        "id": "file-Gj22pvQ433Gk8Y6JJXy5J73Y"
                     }
                 },
                 "multiqc_config_file": {


### PR DESCRIPTION
Update everything in GRCh38 config to latest versions

- Update assay: TWE38 → 38_TWE
- Update version from 2.0.1 → 2.1.0
- Add in changelog details from GRCh37 versions 1.2.0, 1.3.0 and 1.4.0 and add this version
- Update Dias single workflow to v2.7.0
- Update Sentieon instance type
- Add picardQC input run_CollectRnaSeqMetrics to false
- Add mosdepth docker input
- Add sex check thresholds for GRCh38 and output folder
- Update Dias multi workflow to v2.2.0
- Remove references to update_runfolders
- Update eggd_multiqc to v2.0.2
- Update multiqc docker input
- Update MultiQC config file which has GRCh38 thresholds

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_configs/94)
<!-- Reviewable:end -->
