### PR TITLE
In 804 pancan conductor config

### DIFF
--- a/assay_configs/PANCAN/eggd_conductor_eunomia_PCAN_config_v1.0.0.json
+++ b/assay_configs/PANCAN/eggd_conductor_eunomia_PCAN_config_v1.0.0.json
@@ -1,6 +1,6 @@
 {
     "name": "Config for Eunomia pipeline with PANCAN assay",
-    "assay": "PCAN",
+    "assay": "PANCAN",
     "assay_code": "-10011|-10012",
     "version": "1.0.0",
     "details": "Initial release of assay config",
@@ -25,7 +25,7 @@
             "analysis": "analysis_1",
             "per_sample": true,
             "process_fastqs": true,
-            "hold": true,
+            "hold": false,
             "inputs": {
                 "stage-staraligner.fastqs": "INPUT-R1-R2",
                 "stage-starfusion.sf_docker": {

--- a/assay_configs/PANCAN/eggd_conductor_eunomia_PCAN_config_v1.0.0.json
+++ b/assay_configs/PANCAN/eggd_conductor_eunomia_PCAN_config_v1.0.0.json
@@ -26,6 +26,9 @@
             "per_sample": true,
             "process_fastqs": true,
             "hold": false,
+            "extra_args": {
+                "priority": "high"
+            },
             "inputs": {
                 "stage-staraligner.fastqs": "INPUT-R1-R2",
                 "stage-starfusion.sf_docker": {


### PR DESCRIPTION
## Description

- Priority of jobs is now high
- `hold` is false since that was a leftover from TSO500
- `assay` name is changed as it is used to match the assay option field in the JIRA tickets


## Make sure the following is done before opening a PR:
- [ :heavy_check_mark: ] The version in the filename is updated
- [ :heavy_check_mark: ] The version of the config is incremented within the file
- [ :heavy_check_mark: ] The changelog has been updated to describe the changes for this version
- [ :heavy_check_mark: ] The object IDs that have changed between the versions correspond to the expected object (as described in the comment/ticket) i.e. file, workflow, app
- [ :heavy_check_mark: ] The expected object is signed off and in 001
- [ :heavy_check_mark: ] Update the Readme.md if needed
- [ :heavy_check_mark: ] For any workflows or app IDs updated, check the name field is updated too for the correct version

### Checks applied before merging the PR
- [ ] All checklists are done within the PR
- [ ] Once changes are checked - comment on that line with an informing comment (non-blocking) the object name

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_configs/103)
<!-- Reviewable:end -->
