### PR TITLE
Updated TSO500 helios conductor config 

### DIFF
--- a/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.2.6.json
+++ b/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.2.6.json
@@ -1,8 +1,8 @@
 {
     "name": "Config for Helios pipeline with TSO500 assay",
     "assay": "TSO500",
-    "assay_code": "-8471|-8472|-8475|-9689|-10011|-10012|-10040|-10041|-10042|-10043",
-    "version": "2.2.5",
+    "assay_code": "-8471|-8472|-8475|-9689|-10040|-10041|-10042|-10043",
+    "version": "2.2.6",
     "details": "Allocates more storage for the eggd_tso500 app output",
     "changelog": {
         "v1.0.0": "Initial working version",
@@ -20,7 +20,8 @@
         "v2.2.2": "Add new Epic assay codes to assay_code field",
         "v2.2.3": "Update to latest TSO500 vep config file (v1.2.12)",
         "v2.2.4": "Update to latest TSO500 vep config file (v1.2.13)",
-        "v2.2.5": "Update to latest TSO500 vep config file (v1.2.14)"
+        "v2.2.5": "Update to latest TSO500 vep config file (v1.2.14)",
+        "v2.2.6": "Update to latest TSO500 vep config file (v1.2.15).Removed PANCAN codes 10011 and 10012."
     },
     "demultiplex": true,    
     "demultiplex_config": {
@@ -173,7 +174,7 @@
                 "stage-vep.config_file": {
                     "$dnanexus_link": {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-                        "id": "file-GxX4PQ040P99YFK324k8Zzzx"
+                        "id": "file-Gy927J840P95qj95Bvy9Fb2V"
                     }
                 },
                 "stage-vep.transcript_list": {


### PR DESCRIPTION

## Description

Please include a summary of the changes [bug fix? new feature?] and the related issue.
Include the newest vep config (1.2.15) . Removed the PANCAN codes 10011 and 10012

## Make sure the following is done before opening a PR:
- [YES] The version in the filename is updated
- [YES ] The version of the config is incremented within the file
- [ YES] The changelog has been updated to describe the changes for this version
- [YES ] The object IDs that have changed between the versions correspond to the expected object (as described in the comment/ticket) i.e. file, workflow, app
- [ YES] The expected object is signed off and in 001
- [ NA] Update the Readme.md if needed
- [ NA] For any workflows or app IDs updated, check the name field is updated too for the correct version

### Checks applied before merging the PR 
- [YES ] All checklists are done within the PR 
- [ ] Once changes are checked - comment on that line with an informing comment (non-blocking) the object name ##helios conductor config is fine