### PR TITLE
Updated assay field in eunomia config

### DIFF
--- a/assay_configs/PANCAN/eggd_conductor_eunomia_PCAN_config_v1.0.1.json
+++ b/assay_configs/PANCAN/eggd_conductor_eunomia_PCAN_config_v1.0.1.json
@@ -1,6 +1,6 @@
 {
     "name": "Config for Eunomia pipeline with PANCAN assay",
-    "assay": "PANCAN",
+    "assay": "PCAN",
     "assay_code": "-10011|-10012",
     "version": "1.0.0",
     "details": "Initial release of assay config",

--- a/assay_configs/PANCAN/eggd_conductor_eunomia_PCAN_config_v1.0.1.json
+++ b/assay_configs/PANCAN/eggd_conductor_eunomia_PCAN_config_v1.0.1.json
@@ -2,7 +2,7 @@
     "name": "Config for Eunomia pipeline with PANCAN assay",
     "assay": "PCAN",
     "assay_code": "-10011|-10012",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "details": "Initial release of assay config",
     "changelog": {
         "v1.0.0": "Initial release of assay config"

--- a/assay_configs/PANCAN/eggd_conductor_eunomia_PCAN_config_v1.0.1.json
+++ b/assay_configs/PANCAN/eggd_conductor_eunomia_PCAN_config_v1.0.1.json
@@ -5,7 +5,8 @@
     "version": "1.0.1",
     "details": "Initial release of assay config",
     "changelog": {
-        "v1.0.0": "Initial release of assay config"
+        "v1.0.0": "Initial release of assay config",
+        "v1.0.1": "Changed assay field name to be more consistent with DNANexus project naming convention"
     },
     "demultiplex": true,
     "demultiplex_config": {


### PR DESCRIPTION
## Description

- Updated assay field for consistency with DNANexus project naming convention

Please include a summary of the changes [bug fix? new feature?] and the related issue.

## Make sure the following is done before opening a PR:
- [X] The version in the filename is updated
- [X] The version of the config is incremented within the file
- [X] The changelog has been updated to describe the changes for this version
- [ N/A ] The object IDs that have changed between the versions correspond to the expected object (as described in the comment/ticket) i.e. file, workflow, app
- [ ] The expected object is signed off and in 001 <- this needs to change, you can't sign off a change without referring to an open PR
- [ N/A ] Update the Readme.md if needed
- [ N/A ] For any workflows or app IDs updated, check the name field is updated too for the correct version

### Checks applied before merging the PR
- [ ] All checklists are done within the PR
- [ ] Once changes are checked - comment on that line with an informing comment (non-blocking) the object name

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_configs/110)
<!-- Reviewable:end -->
