### PR TITLE
renamed to eggd_conductor_helios_TSO500_config_v2.7.2.json added depe…

### DIFF
--- a/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.7.2.json
+++ b/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.7.2.json
@@ -38,7 +38,7 @@
         "v2.6.0": "Remove ICI uploader",
         "v2.7.0": "Update TSO500 reports workflow to v2.4.0, Picard CollectVariantCallingMetrics, MultiQC config (v2.2.0) and MultiQC docker (v1.28)",
         "v2.7.1": "Update to latest TSO500 vep config file (v1.2.24), Update multi_fastqc v1.1.0 -> eggd_fastqc v1.2.0",
-        "v2.7.2": "Update to include multiQC dependency on eggd_metricsoutput_editor (analysis_3) and TSO500_reports_workflow (analysis_5)"
+        "v2.7.2": "Update to include multiQC dependency on TSO500_reports_workflow (analysis_5)"
     },
     "demultiplex": true,
     "demultiplex_config": {
@@ -281,7 +281,6 @@
             "depends_on": [
                 "analysis_1",
                 "analysis_2",
-                "analysis_3",
                 "analysis_4",
                 "analysis_5"
             ],


### PR DESCRIPTION
…ndency of multiqc on TSO reports

## Description

MultiQC was lacking Picard QC metrics for a number of samples: #181. As this was due to MultiQC completing before the Picard Jobs, the `depends_on` option was used to ensure MultiQC would wait on all other jobs to complete before starting. This is the relative Jira ticket: https://cuhbioinformatics.atlassian.net/browse/DI-2716 


## Make sure the following is done before opening a PR:
- [x] The version in the filename is updated
- [x] The version of the config is incremented within the file
- [x] The changelog has been updated to describe the changes for this version
- [x] The object IDs that have changed between the versions correspond to the expected object (as described in the comment/ticket) i.e. file, workflow, app
- [x] The expected object is signed off and in 001
- [x] Update the Readme.md if needed
- [x] For any workflows or app IDs updated, check the name field is updated too for the correct version

### Checks applied before merging the PR
- [] All checklists are done within the PR
- [ ] Once changes are checked - comment on that line with an informing comment (non-blocking) the object name

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_configs/182)
<!-- Reviewable:end -->
