### PR TITLE
eggd_conductor_dias_CEN_config_v2.5.0 changes

### DIFF
--- a/assay_configs/CEN/eggd_conductor_dias_CEN_config_v2.5.0.json
+++ b/assay_configs/CEN/eggd_conductor_dias_CEN_config_v2.5.0.json
@@ -18,7 +18,7 @@
         "v2.2.0": "Update dias_single to v2.9.0. Sentieon v5.1.0. + eggd_additional_region_calling v1.0.0",
         "v2.3.0": "Update dias_single to v2.10.0. Includes eggd_additional_region_calling v1.1.0",
         "v2.4.0": "Updated assay code to include top up codes.Add subset_samplesheet to inlcude non-top up codes",
-        "v2.5.0": "Updated assay to include eggd_plot_variant_baf. Updated dias_single to v2.14.0,  CEN MultiQC yaml config to v1.2.0 and MultiQC docker to v1.28. Update eggd_MultiQC to v3.2.0 and to receive samplesheet as input."
+        "v2.5.0": "Updated dias_single to v2.14.0 and provided inputs to new app in workflow eggd_plot_variant_baf. Updated eggd_MultiQC to v3.2.0, multiqc_docker to v1.28, CEN MultiQC config v1.2.0 and provided samplesheet as MultiqQC input."
     },
     "demultiplex": true,
     "users": {
@@ -28,7 +28,7 @@
     "executables": {
         "workflow-J3k0PxQ40JxZqpz3XKVpz2qF": {
             "name": "dias_single_v2.14.0",
-            "details": "Dias single workflow - Runs Sentieon, multi_fastqc, verifyBAMID, vcf_QC, flagstat, Picard, mosdepth, somalier extract using the fastqs out of demultiplexing step, and eggd_sex_check",
+            "details": "Dias single workflow - Runs Sentieon, multi_fastqc, verifyBAMID, vcf_QC, flagstat, Picard, mosdepth, somalier extract using the fastqs out of demultiplexing step, eggd_sex_check, and eggd_plot_variant_baf",
             "url": "https://github.com/eastgenomics/eggd_dias_single_workflow",
             "analysis": "analysis_1",
             "per_sample": true,


### PR DESCRIPTION
- Updated filename version and inside the file from v2.4.0 to v2.5.0
- Added a v2.5.0 changelog describing the new changes.
  - Updated the name and workflow ID from dias single workflow to dias_single_v2.10.0 to dias_single_v2.14.0
  - Included stage-eggd_plot_variang_baf app + standard inputs + output folderpath
  - Picard changes:
    - Added stage-picardQC.run_CollectVariantCallingMetrics: true
    - Added stage-picardQC.dbsnp_vcf input
  -  eggd_Multiqc changes:
     - Updated app-id and name from eggd_MultiQC/2.0.2 to eggd_MultiQC/3.2.0
     - Updated multiqc_docker file-id to v1.28
     - Updated CEN multiqc_config file v1.2.0

## Description

Please include a summary of the changes [bug fix? new feature?] and the related issue.


## Make sure the following is done before opening a PR:
- [x] The version in the filename is updated
- [x] The version of the config is incremented within the file
- [x] The changelog has been updated to describe the changes for this version
- [x] The object IDs that have changed between the versions correspond to the expected object (as described in the comment/ticket) i.e. file, workflow, app
- [x] The expected object is signed off and in 001
- [x] Update the Readme.md if needed
- [x] For any workflows or app IDs updated, check the name field is updated too for the correct version

### Checks applied before merging the PR
- [x] All checklists are done within the PR
- [x] Once changes are checked - comment on that line with an informing comment (non-blocking) the object name

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_configs/187)
<!-- Reviewable:end -->
