### PR TITLE
eggd_conductor_dias_TWE_config_v2.5.0 changes

### DIFF
--- a/assay_configs/TWE/eggd_conductor_dias_TWE_config_v2.5.0.json
+++ b/assay_configs/TWE/eggd_conductor_dias_TWE_config_v2.5.0.json
@@ -3,7 +3,7 @@
     "assay": "38_TWE",
     "genome": "GRCh38",
     "assay_code": "-EGG4|-9526-|-9688-|-1288-",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "details": "Includes main Dias workflows: single, multi and QC reports",
     "changelog": {
         "v1.0.0": "Initial working version",
@@ -18,7 +18,8 @@
         "v2.1.1": "Updates hap.py panel BED",
         "v2.2.0": "Update dias_single to v2.9.0. Sentieon v5.1.0. + eggd_additional_region_calling v1.0.0",
         "v2.3.0": "Update dias_single to v2.10.0. Includes eggd_additional_region_calling v1.1.0",
-        "v2.4.0": "Updated assay code to include top up codes.Add subset_samplesheet to include non-top up codes"
+        "v2.4.0": "Updated assay code to include top up codes.Add subset_samplesheet to include non-top up codes",
+        "v2.5.0": "Updated dias_single to v2.14.0 and provided inputs to new app in workflow eggd_plot_variant_baf. Updated eggd_MultiQC to v3.2.0, multiqc_docker to v1.28, CEN MultiQC config v1.2.0 and provided samplesheet as MultiqQC input."
     },
     "demultiplex": true,
     "demultiplex_config": {
@@ -29,9 +30,9 @@
     },
     "subset_samplesheet":"-EGG4|-9526-|-9688-",
     "executables": {
-        "workflow-J1V9g8j400YKZyVYZy2vZQ19": {
-            "name": "dias_single_v2.10.0",
-            "details": "Dias single workflow - Runs Sentieon, multi_fastqc, verifyBAMID, vcf_QC, flagstat, Picard, mosdepth, somalier extract using the fastqs out of demultiplexing step, and eggd_sex_check",
+        "workflow-J3k0PxQ40JxZqpz3XKVpz2qF": {
+            "name": "dias_single_v2.14.0",
+            "details": "Dias single workflow - Runs Sentieon, multi_fastqc, verifyBAMID, vcf_QC, flagstat, Picard, mosdepth, somalier extract using the fastqs out of demultiplexing step, eggd_sex_check, and eggd_plot_variant_baf",
             "url": "https://github.com/eastgenomics/eggd_dias_single_workflow",
             "analysis": "analysis_1",
             "per_sample": true,
@@ -67,6 +68,11 @@
                         "*": {
                             "instanceType": "mem1_ssd2_v2_x4"
                         }
+                    },
+                    "stage-eggd_plot_variant_baf": {
+                        "*": {
+                            "instanceType": "mem3_ssd1_v2_x8"
+                            }
                     }
                 }
             },
@@ -111,6 +117,7 @@
                 "stage-picardQC.run_CollectHsMetrics": true,
                 "stage-picardQC.run_CollectTargetedPcrMetrics": false,
                 "stage-picardQC.run_CollectRnaSeqMetrics": false,
+                "stage-picardQC.run_CollectVariantCallingMetrics": true,
                 "stage-picardQC.fasta_index": {
                     "$dnanexus_link": {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
@@ -121,6 +128,12 @@
                     "$dnanexus_link": {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
                         "id": "file-G7FK1xQ4kj4317YGFpqYPb75"
+                    }
+                },
+                "stage-picardQC.dbsnp_vcf": {
+                    "$dnanexus_link": {
+                        "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+                        "id": "file-GyfBYg8433GkZg7X1B23qFfj"
                     }
                 },
                 "stage-mosdepth.mosdepth_docker": {
@@ -160,6 +173,16 @@
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
                         "id": "file-J0bY10848g1k41qQ6jqk90Z4"
                     }
+                },
+                "stage-eggd_plot_variant_baf.min_baf": 0,
+                "stage-eggd_plot_variant_baf.max_baf": 1,
+                "stage-eggd_plot_variant_baf.max_depth": 0.95,
+                "stage-eggd_plot_variant_baf.genome": "hg38",
+                "stage-eggd_plot_variant_baf.packages": {
+                    "$dnanexus_link": {
+                        "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+                        "id": "file-GzyV1004y5QX260z2yYyjzbK"
+                    }
                 }
             },
             "output_dirs": {
@@ -172,7 +195,8 @@
                 "stage-mosdepth": "/OUT-FOLDER/STAGE-NAME",
                 "stage-somalier_extract": "/OUT-FOLDER/STAGE-NAME",
                 "stage-sex_check": "/OUT-FOLDER/STAGE-NAME",
-                "stage-additional_regions_calling": "/OUT-FOLDER/STAGE-NAME"
+                "stage-additional_regions_calling": "/OUT-FOLDER/STAGE-NAME",
+                "stage-eggd_plot_variant_baf": "/OUT-FOLDER/STAGE-NAME"
             }
         },
         "workflow-Gj2jP6j4PKbJpVgjK417J4X7": {
@@ -263,8 +287,8 @@
                 "stage-somalier_relate2multiqc": "/OUT-FOLDER/STAGE-NAME"
             }
         },
-        "app-Gjyybj844V5bbzXQVfk32Xby": {
-            "name": "eggd_MultiQC/2.0.2",
+        "app-J24Ffv8469JKgKQ88bX2kYF2": {
+            "name": "eggd_MultiQC/3.2.0",
             "details": "",
             "url": "https://github.com/eastgenomics/eggd_multiqc",
             "analysis": "analysis_3",
@@ -284,17 +308,18 @@
             "inputs": {
                 "project_for_multiqc": "INPUT-dx_project_name",
                 "primary_workflow_output": "INPUT-parent_out_dir",
+                "samplesheet": {"$dnanexus_link": "INPUT-SAMPLESHEET"},
                 "calc_custom_coverage": false,
                 "multiqc_docker": {
                     "$dnanexus_link": {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-                        "id": "file-Gj22pvQ433Gk8Y6JJXy5J73Y"
+                        "id": "file-J08KZb04bX05K677bv83GY2q"
                     }
                 },
                 "multiqc_config_file": {
-                    "$dnanexus_link":  {
+                    "$dnanexus_link": {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-                        "id": "file-GxQ342j46J8J4pJ3fJ60qKky"
+                        "id": "file-J4ZvZk849Vpbz6G76kZ6z0Gf"
                     }
                 }
             },


### PR DESCRIPTION
- Updated version in filename and inside the file from v2.4.0 to v2.5.0
- Added a v2.5.0 changelog describing the new changes.
  - Updated the name and workflow ID from dias single workflow to dias_single_v2.10.0 to dias_single_v2.14.0
  - Included stage-eggd_plot_variant_baf app, standard inputs, and output folder path
  - Picard changes:
     - Added stage-picardQC.run_CollectVariantCallingMetrics: true
     - Added stage-picardQC.dbsnp_vcf input
   - eggd_Multiqc changes:
     - Updated app-id and name from eggd_MultiQC/2.0.2 to eggd_MultiQC/3.2.0
     - Updated multiqc_docker file-id to v1.28 - Updated WES multiqc_config file-id to v1.2.0

## Description

Please include a summary of the changes [bug fix? new feature?] and the related issue.


## Make sure the following is done before opening a PR:
- [x] The version in the filename is updated
- [x] The version of the config is incremented within the file
- [x] The changelog has been updated to describe the changes for this version
- [x] The object IDs that have changed between the versions correspond to the expected object (as described in the comment/ticket) i.e. file, workflow, app
- [x] The expected object is signed off and in 001
- [x] Update the Readme.md if needed
- [x] For any workflows or app IDs updated, check the name field is updated too for the correct version

### Checks applied before merging the PR
- [ ] All checklists are done within the PR
- [ ] Once changes are checked - comment on that line with an informing comment (non-blocking) the object name

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_configs/190)
<!-- Reviewable:end -->
