### PR TITLE
NG-690_v2.8.1 update vep config to v1.2.26 and add TSO top up test codes

### DIFF
--- a/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.8.1.json
+++ b/assay_configs/TSO500/eggd_conductor_helios_TSO500_config_v2.8.1.json
@@ -38,7 +38,8 @@
         "v2.6.0": "Remove ICI uploader",
         "v2.7.0": "Update TSO500 reports workflow to v2.4.0, Picard CollectVariantCallingMetrics, MultiQC config (v2.2.0) and MultiQC docker (v1.28)",
         "v2.7.1": "Update to latest TSO500 vep config file (v1.2.24), Update multi_fastqc v1.1.0 -> eggd_fastqc v1.2.0",
-        "v2.8.0": "Update to latest TSO500 vep config file (v1.2.25), Update the athena panel bed, athena exons file and introduce MultiQC dependence on TSO500_reports_workflow (analysis_5)"
+        "v2.8.0": "Update to latest TSO500 vep config file (v1.2.25), Update the athena panel bed, athena exons file and introduce MultiQC dependence on TSO500_reports_workflow (analysis_5)",
+        "v2.8.1": "Update to latest TSO500 vep config file (v1.2.26), Add TSO500 top up test codes 10026 and 10054"
     },
     "demultiplex": true,
     "demultiplex_config": {


### PR DESCRIPTION
## Description

Updates the VEP config ID to point to v1.2.26 and adds top up test codes 10054 and 10026


## Make sure the following is done before opening a PR:
- [x] The version in the filename is updated
- [x] The version of the config is incremented within the file
- [x] The changelog has been updated to describe the changes for this version
- [x] The object IDs that have changed between the versions correspond to the expected object (as described in the comment/ticket) i.e. file, workflow, app
- [x] The expected object is signed off and in 001
- [x] Update the Readme.md if needed
- [x] For any workflows or app IDs updated, check the name field is updated too for the correct version

### Checks applied before merging the PR
- [x] All checklists are done within the PR
- [x] Once changes are checked - comment on that line with an informing comment (non-blocking) the object name

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_configs/199)
<!-- Reviewable:end -->
