### PR TITLE
TWE v3.2.0 - Update dias_single to v2.15.0

### DIFF
--- a/assay_configs/TWE/eggd_conductor_dias_TWE_config_v3.2.0.json
+++ b/assay_configs/TWE/eggd_conductor_dias_TWE_config_v3.2.0.json
@@ -3,7 +3,7 @@
     "assay": "38_TWE",
     "genome": "GRCh38",
     "assay_code": "-EGG4|-9526-|-9688-|-1288-|-10028-",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "details": "Includes main Dias workflows: single, multi and QC reports",
     "changelog": {
         "v1.0.0": "Initial working version",
@@ -23,7 +23,8 @@
         "v2.5.1": "Updated assay code",
         "v2.5.2": "Update the MultiQC config file to fix threshold display issue with Fold80 + Fix MultiQC folder destination",
         "v3.0.0": "Add demultiplex config for handling Twist harmonisation project UMIs",
-        "v3.1.0": "Update eggd_MultiQC to v3.3.0 and TWE MultiQC config file to v1.3.0"
+        "v3.1.0": "Update eggd_MultiQC to v3.3.0 and TWE MultiQC config file to v1.3.0",
+        "v3.2.0": "Updated dias_single to v2.15.0. Includes eggd_vcf_normaliser."
     },
     "demultiplex": true,
     "demultiplex_config": {
@@ -35,9 +36,9 @@
     },
     "subset_samplesheet": "-EGG4|-9526-|-9688-",
     "executables": {
-        "workflow-J3k0PxQ40JxZqpz3XKVpz2qF": {
-            "name": "dias_single_v2.14.0",
-            "details": "Dias single workflow - Runs Sentieon, multi_fastqc, verifyBAMID, vcf_QC, flagstat, Picard, mosdepth, somalier extract using the fastqs out of demultiplexing step, eggd_sex_check, and eggd_plot_variant_baf",
+        "workflow-J70bzZj4F33fBzxY8q694105": {
+            "name": "dias_single_v2.15.0",
+            "details": "Dias single workflow - Runs Sentieon, VCF normaliser, multi_fastqc, verifyBAMID, vcf_QC, flagstat, Picard, mosdepth, somalier extract using the fastqs out of demultiplexing step, eggd_sex_check, and eggd_plot_variant_baf",
             "url": "https://github.com/eastgenomics/eggd_dias_single_workflow",
             "analysis": "analysis_1",
             "per_sample": true,
@@ -104,6 +105,13 @@
                     "$dnanexus_link": {
                         "project": "project-F3zqGV04fXX5j7566869fjFq",
                         "id": "file-F3zvKp84fXX8qJx43zZXP395"
+                    }
+                },
+                "stage-vcf_normaliser.bcftools_options": "-m -any --keep-sum AD",
+                "stage-vcf_normaliser.fasta_tar": {
+                    "$dnanexus_link": {
+                        "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+                        "id": "file-Gb772VQ4XGyzQ0Zk615XbZ0X"
                     }
                 },
                 "stage-verifybamid.vcf_file": {
@@ -201,7 +209,8 @@
                 "stage-somalier_extract": "/OUT-FOLDER/STAGE-NAME",
                 "stage-sex_check": "/OUT-FOLDER/STAGE-NAME",
                 "stage-additional_regions_calling": "/OUT-FOLDER/STAGE-NAME",
-                "stage-eggd_plot_variant_baf": "/OUT-FOLDER/STAGE-NAME"
+                "stage-eggd_plot_variant_baf": "/OUT-FOLDER/STAGE-NAME",
+                "stage-vcf_normaliser": "/OUT-FOLDER/STAGE-NAME"
             }
         },
         "workflow-Gj2jP6j4PKbJpVgjK417J4X7": {


### PR DESCRIPTION
## Description

Update dias_single to v2.15.0 to incorporate eggd_vcf_normaliser


## Make sure the following is done before opening a PR:
- [x] The version in the filename is updated
- [x] The version of the config is incremented within the file
- [x] The changelog has been updated to describe the changes for this version
- [x] The object IDs that have changed between the versions correspond to the expected object (as described in the comment/ticket) i.e. file, workflow, app
- [x] The expected object is signed off and in 001
- [x] Update the Readme.md if needed
- [x] For any workflows or app IDs updated, check the name field is updated too for the correct version

### Checks applied before merging the PR
- [ ] All checklists are done within the PR
- [ ] Once changes are checked - comment on that line with an informing comment (non-blocking) the object name

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_configs/243)
<!-- Reviewable:end -->
